### PR TITLE
Make info message in header match exactly BeamNG message

### DIFF
--- a/src/beamng/cdae/io/cdae_writer.py
+++ b/src/beamng/cdae/io/cdae_writer.py
@@ -149,7 +149,7 @@ class CdaeWriter:
 
         head = MsgpackWriter()
         head_dict = {
-            "info": "Welcome! This is a binary file :D Please read the docs at https://go.beamng.com/shapeMessagepackFileformat",
+            "info": "\r\n\r\n\r\nWelcome! This is a binary file :D\r\nPlease read the docs at https://go.beamng.com/shapeMessagepackFileformat\r\n\r\n\r\n",
             "compression": compress,
             "bodysize": len(body_bytes),
             "objectNames": get_object_names(cdae),


### PR DESCRIPTION
Hi,

I was comparing the binary content for a file produced with this add-on in Blender versus the binary of the same object exported as `.dae` with BLender 4.5.11 default exporter and then converted to `.cdae` by BeamNG 38.6.

I noticed that the header `info` field doesn't match exactly in binary, making the comparaison a little bit harder than it should.

This PR makes the `info` message match exactly the one produced by BeamNG.
