### PR TITLE
Fix cdae mesh without UV export

### DIFF
--- a/src/beamng/cdae/builder.py
+++ b/src/beamng/cdae/builder.py
@@ -279,6 +279,9 @@ class CdaeMeshBuilder:
 
         if npmesh.uvs0 is not None:
             mesh_out.tverts0.set_numpy_array(npmesh.uvs0)
+        else:
+            # generate default UV so the object is visible in BeamNG (default UV values is [0.0, 1.0] as BeamNG does for a .dae without UV)
+            mesh_out.tverts0.set_numpy_array(np.tile(np.array([0.0, 1.0], dtype=np.float32), (len(npmesh.positions), 1)))
 
         if npmesh.uvs1 is not None:
             mesh_out.tverts1.set_numpy_array(npmesh.uvs1)


### PR DESCRIPTION
Fixes #10 

This PR allows to export models without UV to a `.cdae` and have them displayed in BeamNG.

I noticed that BeamNG adds default UV to a `cdae` file produced from a `dae` without UV.
This PR does the same in Blender, with the same value of `[0.0, 1.0]`.

Note: it's a bit of a shame that BeamNG needs to store default normal instead of just generating them at runtime. Maybe in the future they will improve that, and in that case we could remove the default UV generation to have smalled `cdae` files.